### PR TITLE
[#8] 종목, 주가, 주가 지료 엔티티 설계

### DIFF
--- a/src/main/java/vis/backend/demo/stock/domain/StockIndicators.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockIndicators.java
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -21,7 +22,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "stock_indicators")
+@Table(
+        name = "stock_indicators",
+        indexes = {
+                @Index(name = "idx_date_ticker_id", columnList = "trade_date, ticker_id")
+        }
+)
 public class StockIndicators {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/vis/backend/demo/stock/domain/StockIndicators.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockIndicators.java
@@ -1,0 +1,50 @@
+package vis.backend.demo.stock.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "stock_indicators")
+public class StockIndicators {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticker_id", nullable = false)
+    private StockInfo stockInfo;
+
+    @Column(nullable = false)
+    private String tradeDate;
+
+    private BigDecimal rsi;
+
+    private BigDecimal obv;
+
+    private BigDecimal pvt;
+
+    private BigDecimal stochK;
+
+    private BigDecimal stochD;
+
+    private BigDecimal bollingerUp;
+
+    private BigDecimal bollingerDown;
+}

--- a/src/main/java/vis/backend/demo/stock/domain/StockIndicators.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockIndicators.java
@@ -53,4 +53,16 @@ public class StockIndicators {
     private BigDecimal bollingerUp;
 
     private BigDecimal bollingerDown;
+
+    private BigDecimal rsiBollingerUp;
+
+    private BigDecimal rsiBollingerDown;
+
+    private BigDecimal obvBollingerUp;
+
+    private BigDecimal obvBollingerDown;
+
+    private BigDecimal pvtBollingerUp;
+
+    private BigDecimal pvtBollingerDown;
 }

--- a/src/main/java/vis/backend/demo/stock/domain/StockInfo.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockInfo.java
@@ -1,0 +1,35 @@
+package vis.backend.demo.stock.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "stock_info")
+public class StockInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, unique = true, length = 10)
+    private String ticker;
+
+    private String companyName;
+
+    private String sector;
+
+    private String industry;
+
+}

--- a/src/main/java/vis/backend/demo/stock/domain/StockPrice.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockPrice.java
@@ -1,0 +1,36 @@
+package vis.backend.demo.stock.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+
+@Table(name = "stock_price")
+public class StockPrice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticker_id", nullable = false)
+    private StockInfo stockInfo;
+
+    @Column(nullable = false)
+    private String tradeDate;
+
+    private BigDecimal openPrice;
+
+    private BigDecimal closePrice;
+
+    private BigDecimal highPrice;
+
+    private BigDecimal lowPrice;
+
+    private Long volume;
+}

--- a/src/main/java/vis/backend/demo/stock/domain/StockPrices.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockPrices.java
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -21,7 +22,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "stock_prices")
+@Table(
+        name = "stock_prices",
+        indexes = {
+                @Index(name = "idx_date_ticker_id", columnList = "trade_date, ticker_id")
+        }
+)
 public class StockPrices {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/vis/backend/demo/stock/domain/StockPrices.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockPrices.java
@@ -1,0 +1,46 @@
+package vis.backend.demo.stock.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "stock_prices")
+public class StockPrices {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticker_id", nullable = false)
+    private StockInfo stockInfo;
+
+    @Column(nullable = false)
+    private String tradeDate;
+
+    private BigDecimal openPrice;
+
+    private BigDecimal closePrice;
+
+    private BigDecimal highPrice;
+
+    private BigDecimal lowPrice;
+
+    private Long volume;
+}

--- a/src/main/java/vis/backend/demo/stock/repository/StockIndicatorsRepository.java
+++ b/src/main/java/vis/backend/demo/stock/repository/StockIndicatorsRepository.java
@@ -1,0 +1,8 @@
+package vis.backend.demo.stock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import vis.backend.demo.stock.domain.StockIndicators;
+
+public interface StockIndicatorsRepository extends JpaRepository<StockIndicators, Long> {
+
+}

--- a/src/main/java/vis/backend/demo/stock/repository/StockInfoRepository.java
+++ b/src/main/java/vis/backend/demo/stock/repository/StockInfoRepository.java
@@ -1,0 +1,9 @@
+package vis.backend.demo.stock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import vis.backend.demo.stock.domain.StockInfo;
+
+public interface StockInfoRepository extends JpaRepository<StockInfo, Integer> {
+    StockInfo findByTicker(String ticker);
+
+}

--- a/src/main/java/vis/backend/demo/stock/repository/StockPricesRepository.java
+++ b/src/main/java/vis/backend/demo/stock/repository/StockPricesRepository.java
@@ -1,0 +1,8 @@
+package vis.backend.demo.stock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import vis.backend.demo.stock.domain.StockPrices;
+
+public interface StockPricesRepository extends JpaRepository<StockPrices, Long> {
+
+}


### PR DESCRIPTION
## PR 타입
- 기타

## 구현한 기능
- 종목, 주가, 주가 지료 엔티티를 설계했습니다.

## 추후 고려할 내용
- 조회 속도 단축 위한 복합 인덱스 도입 여부에 대해 고민해보려 합니다. 
- 삽입 속도 단축 위한 가상 쓰레드, webclient 방식에 대해 고민해보려 합니다. 

## 일정
- 추정 시간 : 3h
- 걸린 시간 : 10h