### PR TITLE
[#15] 세마포어 및 재시도 로직 추가로 대규모 API 호출 안정성 강화

### DIFF
--- a/src/main/java/vis/backend/demo/global/utils/FetchRetry.java
+++ b/src/main/java/vis/backend/demo/global/utils/FetchRetry.java
@@ -1,0 +1,28 @@
+package vis.backend.demo.global.utils;
+
+import java.util.concurrent.Callable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FetchRetry {
+    public <T> T retry(int maxAttempts, long delayMillis, Callable<T> task, String ticker) throws Exception {
+        int attempt = 0;
+        while (true) {
+            try {
+                return task.call();
+            } catch (Exception e) {
+                attempt++;
+                if (attempt >= maxAttempts || isUnrecoverable(e)) {
+                    throw e;
+                }
+                System.err.println("[" + ticker + "] Retrying... Attempt " + attempt + " due to: " + e.getMessage());
+                Thread.sleep(delayMillis);
+            }
+        }
+    }
+
+    // 예외 메시지 기반으로 재시도 여부 결정
+    private boolean isUnrecoverable(Exception e) {
+        return e.getMessage() != null && e.getMessage().contains("No data found");
+    }
+}

--- a/src/main/java/vis/backend/demo/stock/service/FetchInsertExecutor.java
+++ b/src/main/java/vis/backend/demo/stock/service/FetchInsertExecutor.java
@@ -8,7 +8,6 @@ import org.springframework.util.StopWatch;
 import vis.backend.demo.stock.domain.StockInfo;
 import vis.backend.demo.stock.domain.StockPrices;
 import vis.backend.demo.stock.repository.StockInfoRepository;
-import vis.backend.demo.stock.repository.StockPricesCompositeIdxRepository;
 import vis.backend.demo.stock.strategy.FetchStrategy;
 
 @Slf4j
@@ -18,7 +17,6 @@ public class FetchInsertExecutor {
     private final StockInfoRepository stockInfoRepository;
     private final FetchStrategySelector selector;
     private final StockBatchInserter inserter;
-    private final StockPricesCompositeIdxRepository r;
 
     public void execute(String range) {
         StopWatch stopWatch = new StopWatch();

--- a/src/main/java/vis/backend/demo/stock/service/FetchStrategySelector.java
+++ b/src/main/java/vis/backend/demo/stock/service/FetchStrategySelector.java
@@ -10,10 +10,7 @@ import vis.backend.demo.stock.strategy.FetchStrategy;
 public class FetchStrategySelector {
     private final Map<String, FetchStrategy> strategyMap;
 
-    // 이 부분 좀 더 고려해봐야 함
     public FetchStrategy select(String range) {
-        return "1d".equalsIgnoreCase(range)
-                ? strategyMap.get("virtual")
-                : strategyMap.get("webclient");
+        return strategyMap.get("virtual");
     }
 }

--- a/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetcher.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetcher.java
@@ -102,7 +102,7 @@ public class VirtualThreadFetcher {
             List<Long> volumes = castToLongList(quote.get("volume"));
 
             if (opens == null || closes == null || highs == null || lows == null || volumes == null) {
-                System.out.println("[" + ticker + "] One of the price lists is null");
+                System.out.println("[" + ticker + "] No data found (all nulls or empty)");
                 return List.of();
             }
 
@@ -129,7 +129,7 @@ public class VirtualThreadFetcher {
                 // log.info("[" + ticker + "] " + "[" + date + "] " + "is fetched");
             }
             if (dtos.isEmpty()) {
-                log.error("[" + ticker + "] No data added to DTOs (all nulls or empty)");
+                log.error("[" + ticker + "] No data found (all nulls or empty)");
             }
             return dtos;
 

--- a/src/test/java/vis/backend/demo/global/utils/FetchRetryTest.java
+++ b/src/test/java/vis/backend/demo/global/utils/FetchRetryTest.java
@@ -1,0 +1,65 @@
+package vis.backend.demo.global.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class FetchRetryTest {
+
+    private final FetchRetry fetchRetry = new FetchRetry();
+
+    @Test
+    void 성공적으로_첫_시도에_성공하면_재시도_없이_종료된다() throws Exception {
+        String result = fetchRetry.retry(3, 100, () -> "success", "AAPL");
+
+        assertEquals("success", result);
+    }
+
+    @Test
+    void 실패하다가_재시도_끝에_성공하면_정상_리턴된다() throws Exception {
+        AtomicInteger attempt = new AtomicInteger(0);
+
+        String result = fetchRetry.retry(3, 100, () -> {
+            if (attempt.incrementAndGet() < 2) {
+                throw new RuntimeException("Temporary error");
+            }
+            return "recovered";
+        }, "TSLA");
+
+        assertEquals("recovered", result);
+        assertEquals(2, attempt.get());
+    }
+
+    @Test
+    void 최대_재시도_횟수를_초과하면_예외를_던진다() {
+        AtomicInteger attempt = new AtomicInteger(0);
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            fetchRetry.retry(2, 100, () -> {
+                attempt.incrementAndGet();
+                throw new RuntimeException("Keep failing");
+            }, "MSFT");
+        });
+
+        assertTrue(exception.getMessage().contains("Keep failing"));
+        assertEquals(2, attempt.get());
+    }
+
+    @Test
+    void 복구불가능한_예외는_재시도_하지_않고_즉시_실패한다() {
+        AtomicInteger attempt = new AtomicInteger(0);
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            fetchRetry.retry(3, 100, () -> {
+                attempt.incrementAndGet();
+                throw new RuntimeException("No data found for symbol");
+            }, "GOOG");
+        });
+
+        assertTrue(exception.getMessage().contains("No data found"));
+        assertEquals(1, attempt.get()); // 재시도 안 함
+    }
+}


### PR DESCRIPTION
## PR 타입
- 기능 추가
- 리펙토링
- 기타

## 구현한 기능
- 대량 요청 시 Yahoo Finance API에서 발생하는 `Connection reset`, `Handshake terminated` 등의 I/O 예외 대응
- `Semaphore`를 활용해 동시에 처리하는 요청 수를 제한 (현재 최대 1000개)
- 일시적 네트워크 예외(I/O error, reset 등)에 대해 최대 3회 재시도(backoff delay 포함)
- 재시도 유틸 클래스를 별도로 분리해 재사용 가능하도록 구성

## 고민해볼 내용
- WebClient 전략에도 동일한 제한 및 재시도 로직을 적용할 필요성
- delay 기준 및 세마포어 동시성 제한 수치 조정 필요성 (지금은 1000)

## 기타
- 재시도 로직은 `No data found`와 같은 비복구 예외는 제외하고 동작
- `Thread.sleep()` 사용으로 인한 blocking 구조지만, VirtualThread 환경에서는 비용 적음

## 테스트 결과
![image](https://github.com/user-attachments/assets/1fa66d36-b49a-498b-8737-a5b5c11fee9c)


## 일정
- 추정 시간: 반나절  
- 걸린 시간: 약 4~5시간 (세마포어와 재시도 조합, 테스트 포함)
