### PR TITLE
[#18] 에러 메시지 포맷 통일 및 무결성 검증 실패 처리 일원화

### DIFF
--- a/src/main/java/vis/backend/demo/global/utils/FetchRetry.java
+++ b/src/main/java/vis/backend/demo/global/utils/FetchRetry.java
@@ -1,8 +1,10 @@
 package vis.backend.demo.global.utils;
 
 import java.util.concurrent.Callable;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class FetchRetry {
     public <T> T retry(int maxAttempts, long delayMillis, Callable<T> task, String ticker) throws Exception {
@@ -15,7 +17,7 @@ public class FetchRetry {
                 if (attempt >= maxAttempts || isUnrecoverable(e)) {
                     throw e;
                 }
-                System.err.println("[" + ticker + "] Retrying... Attempt " + attempt + " due to: " + e.getMessage());
+                log.error("[" + ticker + "] Retrying... Attempt " + attempt + " due to: " + e.getMessage());
                 Thread.sleep(delayMillis);
             }
         }
@@ -23,6 +25,9 @@ public class FetchRetry {
 
     // 예외 메시지 기반으로 재시도 여부 결정
     private boolean isUnrecoverable(Exception e) {
-        return e.getMessage() != null && e.getMessage().contains("No data found");
+        String message = e.getMessage();
+        return message != null && (
+                message.contains("No data found") || message.contains("404 Not Found")
+        );
     }
 }

--- a/src/main/java/vis/backend/demo/stock/service/FetchInsertExecutor.java
+++ b/src/main/java/vis/backend/demo/stock/service/FetchInsertExecutor.java
@@ -27,6 +27,7 @@ public class FetchInsertExecutor {
         stopWatch.start("fetch");
         List<StockPrices> data = strategy.fetch(stockInfos, range);
         stopWatch.stop();
+        log.info("fetch end");
 
         stopWatch.start("insert");
         inserter.batchInsertIgnore(data);

--- a/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetchStrategy.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetchStrategy.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import vis.backend.demo.global.utils.FetchRetry;
 import vis.backend.demo.stock.converter.StockPricesConverter;
@@ -15,6 +16,7 @@ import vis.backend.demo.stock.domain.StockInfo;
 import vis.backend.demo.stock.domain.StockPrices;
 import vis.backend.demo.stock.dto.StockDto;
 
+@Slf4j
 @Component("virtual")
 @RequiredArgsConstructor
 public class VirtualThreadFetchStrategy implements FetchStrategy {
@@ -50,7 +52,12 @@ public class VirtualThreadFetchStrategy implements FetchStrategy {
                 try {
                     results.addAll(future.get(10, TimeUnit.SECONDS));
                 } catch (Exception e) {
-                    System.err.println("VirtualThread task failed: " + e.getMessage());
+                    String message = e.getMessage();
+                    if (message.contains("No data found") || message.contains("404 Not Found")) {
+                        log.error(e.getMessage());
+                    } else {
+                        log.error("VirtualThread task failed: " + e.getMessage());
+                    }
                 }
             }
 

--- a/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetcher.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetcher.java
@@ -102,8 +102,7 @@ public class VirtualThreadFetcher {
             List<Long> volumes = castToLongList(quote.get("volume"));
 
             if (opens == null || closes == null || highs == null || lows == null || volumes == null) {
-                System.out.println("[" + ticker + "] No data found (all nulls or empty)");
-                return List.of();
+                throw new RuntimeException("[" + ticker + "] No data found");
             }
 
             int minSize = Stream.of(opens.size(), closes.size(), highs.size(), lows.size(), volumes.size(),
@@ -126,16 +125,18 @@ public class VirtualThreadFetcher {
                         .lowPrice(BigDecimal.valueOf(lows.get(i)))
                         .volume(volumes.get(i))
                         .build());
-                // log.info("[" + ticker + "] " + "[" + date + "] " + "is fetched");
             }
             if (dtos.isEmpty()) {
-                log.error("[" + ticker + "] No data found (all nulls or empty)");
+                throw new RuntimeException("[" + ticker + "] No data found");
             }
             return dtos;
 
         } catch (Exception e) {
-            log.error("[" + ticker + "] Exception: " + e.getMessage());
-            return List.of();
+            if (e.getMessage().contains("No data found")) {
+                throw new RuntimeException(e.getMessage());
+            } else {
+                throw new RuntimeException("[" + ticker + "] " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
## PR 타입
- 리펙토링

## 구현한 기능
- 에러 메시지 포맷을 일관되게 통일하여 로그 기반 디버깅 및 추적 용이성 향상
- No data found, 404 Not Found와 같은 예외 메시지를 명시적으로 throw하여 재시도 로직과 로그 검색 조건 간의 일관성 확보
- FetchRetry 유틸에서 재시도 여부 판단을 메시지 기반으로 수행하도록 개선
- 예외 발생 및 로깅, 재시도 여부 판단의 흐름을 일원화하여 예외 처리 책임이 명확하게 분리됨

## 추가 고려해야 할 내용
- 429에 대한 근본적인 해결을 위해 지수 백오프(backoff) 전략 도입이 필요한지
- 현재 세마포어 1000과 딜레이 2초 조합이 가장 이상적인지 추가 실험 필요
* 만건(하루 단위 데이터) 초과의 데이터 요청시 현재의 재시도 로직과 semaphore로 429 에러가 발생함.   
![image](https://github.com/user-attachments/assets/e030ce9c-9ebe-4a55-8cf0-5a0cb995aea0)

## 테스트 결과
세마포어 + 재시도 적용 전: 단기간 다량 요청 시 429 에러로 인해 일부 티커 누락
적용 후: 하루 단위 전체 티커 데이터 세트에 대해 3회 연속 실행 시도 결과, 100% 성공적으로 수행
![image](https://github.com/user-attachments/assets/c569fadd-292a-4d49-ab32-34e726996689)

재시도 관련 로그 예시
![image](https://github.com/user-attachments/assets/e43d191c-30b9-4451-80f1-6cde1b18aad2)
![image](https://github.com/user-attachments/assets/2950641e-634c-4c79-8aec-95e96a043258)

## 일정
- 추정 시간: 2h
- 걸린 시간: 약 2.5h (테스트 및 반복 실험 포함)

