### PR TITLE
[#22] 복합키 (trade_date, ticker_id)를 primary key로 설정

### DIFF
--- a/src/main/java/vis/backend/demo/stock/converter/StockPricesConverter.java
+++ b/src/main/java/vis/backend/demo/stock/converter/StockPricesConverter.java
@@ -1,14 +1,17 @@
 package vis.backend.demo.stock.converter;
 
 import vis.backend.demo.stock.domain.StockInfo;
-import vis.backend.demo.stock.domain.StockPrices;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
 import vis.backend.demo.stock.dto.StockDto;
 
 public class StockPricesConverter {
-    public static StockPrices toEntity(StockDto.StockPricesSimpleDto dto, StockInfo stockInfo) {
-        return StockPrices.builder()
-                .stockInfo(stockInfo)
+    public static StockPricesCompositeIdx toEntity(
+            StockDto.StockPricesSimpleDto dto, StockInfo stockInfo) {
+
+        return StockPricesCompositeIdx.builder()
                 .tradeDate(dto.getTradeDate())
+                .tickerId(stockInfo.getId())
+                .stockInfo(stockInfo)
                 .openPrice(dto.getOpenPrice())
                 .closePrice(dto.getClosePrice())
                 .highPrice(dto.getHighPrice())

--- a/src/main/java/vis/backend/demo/stock/domain/StockPricesCompositeIdx.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockPricesCompositeIdx.java
@@ -1,48 +1,52 @@
 package vis.backend.demo.stock.domain;
 
-import jakarta.persistence.EmbeddedId;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
-import lombok.AccessLevel;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(
         name = "stock_prices_composite_idx",
-        indexes = {
-                @Index(name = "idx_date", columnList = "trade_date")
-        }
+        indexes = @Index(name = "idx_ticker", columnList = "ticker_id")
 )
+@IdClass(StockPricesId.class)
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Builder
 public class StockPricesCompositeIdx {
 
-    @EmbeddedId
-    private StockPricesId id; // 복합 PK 사용
+    @Id
+    @Column(name = "trade_date", nullable = false)
+    private LocalDate tradeDate;        // PK 1
+
+    @Id
+    @Column(name = "ticker_id", nullable = false)
+    private Integer tickerId;           // PK 2
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("stockInfo")
-    @JoinColumn(name = "ticker_id", nullable = false)
+    @JoinColumn(name = "ticker_id",
+            insertable = false,
+            updatable = false)
     private StockInfo stockInfo;
 
     private BigDecimal openPrice;
-
     private BigDecimal closePrice;
-
     private BigDecimal highPrice;
-
     private BigDecimal lowPrice;
-
     private Long volume;
 }

--- a/src/main/java/vis/backend/demo/stock/domain/StockPricesId.java
+++ b/src/main/java/vis/backend/demo/stock/domain/StockPricesId.java
@@ -1,39 +1,16 @@
 package vis.backend.demo.stock.domain;
 
-import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.Objects;
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Embeddable
+@Data               // equals/hashCode 포함
+@NoArgsConstructor
+@AllArgsConstructor
 public class StockPricesId implements Serializable {
-    private Integer stockInfo;
-    @Getter
-    private LocalDate tradeDate;
+    private LocalDate tradeDate;   // PK 1
+    private Integer tickerId;     // PK 2
 
-    public StockPricesId() {
-    }
-
-    public StockPricesId(Integer stockInfo, LocalDate tradeDate) {
-        this.stockInfo = stockInfo;
-        this.tradeDate = tradeDate;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        StockPricesId that = (StockPricesId) o;
-        return stockInfo.equals(that.stockInfo) && tradeDate.equals(that.tradeDate);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(stockInfo, tradeDate);
-    }
 }

--- a/src/main/java/vis/backend/demo/stock/service/FetchInsertExecutor.java
+++ b/src/main/java/vis/backend/demo/stock/service/FetchInsertExecutor.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 import vis.backend.demo.stock.domain.StockInfo;
-import vis.backend.demo.stock.domain.StockPrices;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
 import vis.backend.demo.stock.repository.StockInfoRepository;
 import vis.backend.demo.stock.strategy.FetchStrategy;
 
@@ -28,13 +28,13 @@ public class FetchInsertExecutor {
         FetchStrategy strategy = fetchStrategySelector.select(range);
         List<StockInfo> stockInfos = stockInfoRepository.findAll();
 
-        int batchSize = 100;
+        int batchSize = strategy.getBatchSize();
         for (int i = 0; i < stockInfos.size(); i += batchSize) {
             int end = Math.min(i + batchSize, stockInfos.size());
             List<StockInfo> batch = stockInfos.subList(i, end);
 
             fetchStopWatch.start();
-            List<StockPrices> data = strategy.fetch(batch, range);
+            List<StockPricesCompositeIdx> data = strategy.fetch(batch, range);
             fetchStopWatch.stop();
 
             insertStopWatch.start();

--- a/src/main/java/vis/backend/demo/stock/service/StockBatchInserter.java
+++ b/src/main/java/vis/backend/demo/stock/service/StockBatchInserter.java
@@ -4,23 +4,29 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
-import vis.backend.demo.stock.domain.StockPrices;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
 
 @Service
 @RequiredArgsConstructor
 public class StockBatchInserter {
+
     private final JdbcTemplate jdbcTemplate;
 
-    public void batchInsertIgnore(List<StockPrices> list) {
+    /**
+     * 1만 건씩 INSERT IGNORE Batch
+     */
+    public void batchInsertIgnore(List<StockPricesCompositeIdx> list) {
+
         String sql = """
-                    INSERT IGNORE INTO stock_prices
-                    (ticker_id, trade_date, open_price, close_price, high_price, low_price, volume)
+                    INSERT IGNORE INTO stock_prices_composite_idx
+                      (trade_date, ticker_id,
+                       open_price, close_price, high_price, low_price, volume)
                     VALUES (?, ?, ?, ?, ?, ?, ?)
                 """;
 
-        jdbcTemplate.batchUpdate(sql, list, 10000, (ps, entity) -> {
-            ps.setInt(1, entity.getStockInfo().getId());
-            ps.setDate(2, java.sql.Date.valueOf(entity.getTradeDate()));
+        jdbcTemplate.batchUpdate(sql, list, 10_000, (ps, entity) -> {
+            ps.setDate(1, java.sql.Date.valueOf(entity.getTradeDate()));
+            ps.setInt(2, entity.getTickerId());
             ps.setBigDecimal(3, entity.getOpenPrice());
             ps.setBigDecimal(4, entity.getClosePrice());
             ps.setBigDecimal(5, entity.getHighPrice());

--- a/src/main/java/vis/backend/demo/stock/strategy/FetchStrategy.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/FetchStrategy.java
@@ -2,10 +2,14 @@ package vis.backend.demo.stock.strategy;
 
 import java.util.List;
 import vis.backend.demo.stock.domain.StockInfo;
-import vis.backend.demo.stock.domain.StockPrices;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
 
 public interface FetchStrategy {
-    List<StockPrices> fetch(List<StockInfo> infos, String range);
+    List<StockPricesCompositeIdx> fetch(List<StockInfo> infos, String range);
 
     String getType();
+
+    default int getBatchSize() {
+        return 100;
+    }
 }

--- a/src/main/java/vis/backend/demo/stock/strategy/MultiThreadFetchStrategy.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/MultiThreadFetchStrategy.java
@@ -1,0 +1,97 @@
+package vis.backend.demo.stock.strategy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import vis.backend.demo.global.utils.FetchRetry;
+import vis.backend.demo.stock.converter.StockPricesConverter;
+import vis.backend.demo.stock.domain.StockInfo;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
+import vis.backend.demo.stock.dto.StockDto;
+
+@Slf4j
+@Component("fixed")
+@RequiredArgsConstructor
+public class MultiThreadFetchStrategy implements FetchStrategy {
+
+    private final VirtualThreadFetcher fetcher;
+    private final FetchRetry fetchRetry;
+
+    @Override
+    public List<StockPricesCompositeIdx> fetch(List<StockInfo> infos, String range) {
+        List<StockPricesCompositeIdx> results = new ArrayList<>();
+        double failedCount = 0.0;
+        List<String> failedTickers = new ArrayList<>();
+
+        int threadPoolSize = Math.min(32, infos.size());
+        try (var executor = Executors.newFixedThreadPool(threadPoolSize)) {
+            Semaphore semaphore = new Semaphore(1000);
+
+            List<Callable<List<StockPricesCompositeIdx>>> tasks = infos.stream()
+                    .map(info -> (Callable<List<StockPricesCompositeIdx>>) () -> {
+                        semaphore.acquire();
+                        try {
+                            List<StockDto.StockPricesSimpleDto> dtos = fetchRetry.retry(3, 2000,
+                                    () -> fetcher.fetch(info.getTicker(), range), info.getTicker());
+                            return dtos.stream()
+                                    .map(dto -> StockPricesConverter.toEntity(dto, info))
+                                    .toList();
+                        } finally {
+                            semaphore.release();
+                        }
+                    })
+                    .toList();
+
+            List<Future<List<StockPricesCompositeIdx>>> futures = executor.invokeAll(tasks);
+
+            for (int i = 0; i < futures.size(); i++) {
+                StockInfo info = infos.get(i);
+                try {
+                    results.addAll(futures.get(i).get(10, TimeUnit.SECONDS));
+                } catch (Exception e) {
+                    String message = e.getMessage();
+                    if (message.contains("No data found") || message.contains("404 Not Found")) {
+                        log.error(e.getMessage());
+                    } else {
+                        log.error("FixedThread task failed: " + e.getMessage());
+                        failedCount++;
+                        failedTickers.add(info.getTicker());
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("FixedThread execution failed", e);
+        }
+
+        double total = infos.size();
+        double failRate = (failedCount / total) * 100;
+        double successRate = ((total - failedCount) / total) * 100;
+
+        log.info("FixedThreadFetch completed. Total: {}, Failed: {} ({}%), Success: {} ({}%)",
+                (int) total,
+                (int) failedCount,
+                String.format("%.2f", failRate),
+                (int) (total - failedCount),
+                String.format("%.2f", successRate)
+        );
+
+        if (!failedTickers.isEmpty()) {
+            log.warn("Failed tickers: {}", String.join(", ", failedTickers));
+        }
+
+        return results;
+    }
+
+    @Override
+    public String getType() {
+        return "fixed";
+    }
+}

--- a/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadBatchFetchStrategy.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadBatchFetchStrategy.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import vis.backend.demo.global.utils.FetchRetry;
 import vis.backend.demo.stock.converter.StockPricesConverter;
 import vis.backend.demo.stock.domain.StockInfo;
-import vis.backend.demo.stock.domain.StockPrices;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
 
 @Slf4j
 @Component("batch")
@@ -24,16 +24,16 @@ public class VirtualThreadBatchFetchStrategy implements FetchStrategy {
     private final FetchRetry fetchRetry;
 
     @Override
-    public List<StockPrices> fetch(List<StockInfo> infos, String range) {
-        List<StockPrices> results = new ArrayList<>();
+    public List<StockPricesCompositeIdx> fetch(List<StockInfo> infos, String range) {
+        List<StockPricesCompositeIdx> results = new ArrayList<>();
         double failedCount = 0.0;
         List<String> failedTickers = new ArrayList<>();
 
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             Semaphore semaphore = new Semaphore(10);
 
-            List<Callable<List<StockPrices>>> tasks = infos.stream()
-                    .map(info -> (Callable<List<StockPrices>>) () -> {
+            List<Callable<List<StockPricesCompositeIdx>>> tasks = infos.stream()
+                    .map(info -> (Callable<List<StockPricesCompositeIdx>>) () -> {
                         semaphore.acquire();
                         try {
                             var dtos = fetchRetry.retry(3, 2000,
@@ -47,7 +47,7 @@ public class VirtualThreadBatchFetchStrategy implements FetchStrategy {
                     })
                     .toList();
 
-            List<Future<List<StockPrices>>> futures = executor.invokeAll(tasks);
+            List<Future<List<StockPricesCompositeIdx>>> futures = executor.invokeAll(tasks);
 
             for (int i = 0; i < futures.size(); i++) {
                 StockInfo info = infos.get(i);

--- a/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetchStrategy.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/VirtualThreadFetchStrategy.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import vis.backend.demo.global.utils.FetchRetry;
 import vis.backend.demo.stock.converter.StockPricesConverter;
 import vis.backend.demo.stock.domain.StockInfo;
-import vis.backend.demo.stock.domain.StockPrices;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
 import vis.backend.demo.stock.dto.StockDto;
 
 @Slf4j
@@ -25,16 +25,16 @@ public class VirtualThreadFetchStrategy implements FetchStrategy {
     private final FetchRetry fetchRetry;
 
     @Override
-    public List<StockPrices> fetch(List<StockInfo> infos, String range) {
-        List<StockPrices> results = new ArrayList<>();
+    public List<StockPricesCompositeIdx> fetch(List<StockInfo> infos, String range) {
+        List<StockPricesCompositeIdx> results = new ArrayList<>();
         double failedCount = 0.0;
         List<String> failedTickers = new ArrayList<>();
 
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             Semaphore semaphore = new Semaphore(1000);
 
-            List<Callable<List<StockPrices>>> tasks = infos.stream()
-                    .map(info -> (Callable<List<StockPrices>>) () -> {
+            List<Callable<List<StockPricesCompositeIdx>>> tasks = infos.stream()
+                    .map(info -> (Callable<List<StockPricesCompositeIdx>>) () -> {
                         semaphore.acquire();
                         try {
                             List<StockDto.StockPricesSimpleDto> dtos = fetchRetry.retry(3, 2000,
@@ -48,7 +48,7 @@ public class VirtualThreadFetchStrategy implements FetchStrategy {
                     })
                     .toList();
 
-            List<Future<List<StockPrices>>> futures = executor.invokeAll(tasks);
+            List<Future<List<StockPricesCompositeIdx>>> futures = executor.invokeAll(tasks);
 
             for (int i = 0; i < futures.size(); i++) {
                 StockInfo info = infos.get(i);
@@ -92,5 +92,10 @@ public class VirtualThreadFetchStrategy implements FetchStrategy {
     @Override
     public String getType() {
         return "virtual";
+    }
+
+    @Override
+    public int getBatchSize() {
+        return 10000;
     }
 }

--- a/src/main/java/vis/backend/demo/stock/strategy/WebClientFetchStrategy.java
+++ b/src/main/java/vis/backend/demo/stock/strategy/WebClientFetchStrategy.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import vis.backend.demo.stock.converter.StockPricesConverter;
 import vis.backend.demo.stock.domain.StockInfo;
-import vis.backend.demo.stock.domain.StockPrices;
+import vis.backend.demo.stock.domain.StockPricesCompositeIdx;
 
 @Component("webclient")
 @RequiredArgsConstructor
@@ -16,9 +16,9 @@ public class WebClientFetchStrategy implements FetchStrategy {
     private final WebClientFetcher fetcher;
 
     @Override
-    public List<StockPrices> fetch(List<StockInfo> infos, String range) {
+    public List<StockPricesCompositeIdx> fetch(List<StockInfo> infos, String range) {
         // 비동기 호출 → 병렬 실행
-        List<CompletableFuture<List<StockPrices>>> futures = infos.stream()
+        List<CompletableFuture<List<StockPricesCompositeIdx>>> futures = infos.stream()
                 .map(info -> CompletableFuture.supplyAsync(() ->
                         fetcher.fetch(info.getTicker(), range).stream()
                                 .map(dto -> StockPricesConverter.toEntity(dto, info))


### PR DESCRIPTION
## PR 타입
- 리펙토링

## 구현한 기능
- 복합키 (trade_date, ticker_id)를 primary key로 설정했습니다. 

## 테스트 결과
- 현재 적재된 데이터가 약 2천만건인데, 적재 속도는 이전과 유사하거나 아주 미미하게 더 빠릅니다. 

## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day